### PR TITLE
ci: build eget + stew compatible archive

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -111,8 +111,8 @@ jobs:
       run: |
         mkdir -p archives
         tree
-        tar -czvf archives/await-${{ steps.get_version.outputs.VERSION }}-aarch64-x86_64-apple-darwin.tar.gz -C await-macos-latest .
-        tar -czvf archives/await-${{ steps.get_version.outputs.VERSION }}-x86_64-unknown-linux-gnu.tar.gz -C await-ubuntu-latest .
+        tar -czvf archives/await-${{ steps.get_version.outputs.VERSION }}-aarch64-x86_64-apple-darwin.tar.gz --strip-components=1 -C await-macos-latest .
+        tar -czvf archives/await-${{ steps.get_version.outputs.VERSION }}-x86_64-unknown-linux-gnu.tar.gz --strip-components=1 -C await-ubuntu-latest .
         tree
 
     - name: Upload Release Artifacts


### PR DESCRIPTION
by stripping the leading `./`, eg:

```
# status quo
❯  tar -czvf await.tar.gz -C await .
a .
a ./await.bash
a ./await.zsh
a ./await.fish

# with strip-components
❯  tar -czvf await.tar.gz --strip-components=1 -C await .
a await.bash
a await.zsh
a await.fish
```

should hopefully resolve #13